### PR TITLE
Add workshop agreement link button

### DIFF
--- a/PalworldModUploader/MainWindow.xaml
+++ b/PalworldModUploader/MainWindow.xaml
@@ -368,7 +368,12 @@
             <Button Content="Guide"
                     Width="90"
                     Height="32"
+                    Margin="0,0,12,0"
                     Click="HelpButton_Click" />
+            <Button Content="Workshop Agreement"
+                    Width="170"
+                    Height="32"
+                    Click="WorkshopAgreementButton_Click" />
         </StackPanel>
 
 

--- a/PalworldModUploader/MainWindow.xaml.cs
+++ b/PalworldModUploader/MainWindow.xaml.cs
@@ -45,6 +45,7 @@ public partial class MainWindow : Window
         { "PalSchema", new[] { "./PalSchema/" } }
     };
     private const string HelpUrl = "https://github.com/pocketpairjp/PalworldModUploader/blob/main/README.md";
+    private const string WorkshopAgreementUrl = "https://steamcommunity.com/sharedfiles/workshoplegalagreement";
 
     private readonly ObservableCollection<ModDirectoryEntry> _modEntries = new();
     private readonly Dictionary<string, ulong> _subscribedFolders = new(StringComparer.OrdinalIgnoreCase);
@@ -873,19 +874,25 @@ public partial class MainWindow : Window
         StatusTextBlock.Text = "Submitting workshop update...";
     }
 
-    private void HelpButton_Click(object sender, RoutedEventArgs e)
+    private void HelpButton_Click(object sender, RoutedEventArgs e) =>
+        OpenUrl(HelpUrl, "Help Error", "Failed to open help documentation");
+
+    private void WorkshopAgreementButton_Click(object sender, RoutedEventArgs e) =>
+        OpenUrl(WorkshopAgreementUrl, "Workshop Agreement Error", "Failed to open the Steam Workshop legal agreement");
+
+    private void OpenUrl(string url, string errorTitle, string errorDescription)
     {
         try
         {
-            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            Process.Start(new ProcessStartInfo
             {
-                FileName = HelpUrl,
+                FileName = url,
                 UseShellExecute = true
             });
         }
         catch (Exception ex)
         {
-            MessageBox.Show($"Failed to open help documentation: {ex.Message}", "Help Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            MessageBox.Show($"{errorDescription}: {ex.Message}", errorTitle, MessageBoxButton.OK, MessageBoxImage.Error);
         }
     }
 


### PR DESCRIPTION
## Summary
- add a Workshop Agreement button next to the existing Guide button
- open the Steam Workshop legal agreement in the user’s browser via a shared helper

## Testing
- not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6940fa767f0c832ba29799abebbea64e)