### PR TITLE
Track subscribed items by ID

### DIFF
--- a/PalworldModUploader/MainWindow.xaml.cs
+++ b/PalworldModUploader/MainWindow.xaml.cs
@@ -265,30 +265,6 @@ public partial class MainWindow : Window
             }
 
             var publishedFileId = details.m_nPublishedFileId;
-            var state = (EItemState)SteamUGC.GetItemState(publishedFileId);
-            if (!state.HasFlag(EItemState.k_EItemStateInstalled))
-            {
-                continue;
-            }
-
-            if (!SteamUGC.GetItemInstallInfo(publishedFileId, out _, out var installFolder, 1024u, out _))
-            {
-                continue;
-            }
-
-            if (!Directory.Exists(installFolder))
-            {
-                continue;
-            }
-
-            var modDirectory = new DirectoryInfo(installFolder);
-            var parentDirectory = modDirectory.Parent;
-            if (parentDirectory == null)
-            {
-                continue;
-            }
-
-            _workshopContentDirectory ??= parentDirectory.FullName;
             subscribedItemIds.Add(publishedFileId.m_PublishedFileId);
         }
     }


### PR DESCRIPTION
## Summary
- replace the subscribed folder mapping with a list of published file IDs from Steam results
- determine subscription status by matching directory names to subscribed item IDs

## Testing
- dotnet build PalworldModUploader.sln *(fails: dotnet command unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6943a6b12c04832b84257a18195dcaee)